### PR TITLE
Langage épicène pour 2016.pycon.fr

### DIFF
--- a/content/2016.05.dates.et.locaux.rst
+++ b/content/2016.05.dates.et.locaux.rst
@@ -26,22 +26,23 @@ Télécom Bretagne du 13 au 16 octobre 2016.
 Qu'est-ce que PyCon-fr ?
 ========================
 
-PyCon-fr c'est le grand rassemblement annuel des développeurs Python
+PyCon-fr c'est le grand rassemblement annuel des développeu·rs·ses Python
 francophones. Organisée chaque année depuis 10 ans par `l'AFPy`_ cette
-conférence regroupe professionnels, chercheurs, étudiants et amateurs
-autour d'une même passion pour le langage de programmation Python_.
+conférence regroupe professionnel·le·s, chercheu·rs·ses, étudiant·e·s et
+amat·eurs·rices autour d'une même passion pour le langage de programmation
+Python_.
 
 .. _`l'AFPy`: http://www.afpy.org/
 .. _Python: http://www.python.org/
 
 
-Tous acteurs de la fête
-=======================
+Tou·te·s act·eurs·rices de la fête
+==================================
 
 PyCon-fr c'est l'ocassion de se rencontrer de partager, d'apprendre et
 de collaborer dans la joie et la bonne humeur.
 
-Vous êtes toutes et tous les bienvenus et nous comptons sur vous pour
+Vous êtes tou·te·s les bienvenu·e·s et nous comptons sur vous pour
 nous présenter vos découvertes, vos retours d'expériences, les
 techniques et briques libres que vous utilisez mais aussi les projets
 que vous réalisez avec ce merveilleux langage.
@@ -51,12 +52,12 @@ Le respect et l'ouverture au cœur de l'événement
 ================================================
 
 Afin que nous puissions tous profiter et nous sentir à l'aise durant
-l'événement vous demanderons de respecter `la charte de l'AFPy`_
+l'événement, nous vous demanderons de respecter `la charte de l'AFPy`_
 durant l'événement. Une équipe sera également en place pour gérer les
 incidents et faire en sorte que la charte soit respectée.
 
-Nous ferons tout notre possible pour que chaque participant puisse se
-sentir chez lui et en sécurité durant l'événement.
+Nous ferons tout notre possible pour que chaque participant·e puisse se
+sentir chez lui·elle et en sécurité durant l'événement.
 
 .. _`la charte de l'AFPy`: http://www.afpy.org/doc/afpy/charte.html
 
@@ -64,19 +65,19 @@ sentir chez lui et en sécurité durant l'événement.
 Proposez un sprint ou une conférence
 ====================================
 
-Cette conférence est la vôtre et vous avez toutes et tous une
+Cette conférence est la vôtre et vous avez tou·te·s une
 expérience à partager et ce quelque soit votre niveau.
 
-Les années précédentes les expériences de débutants ont été très
+Les années précédentes les expériences de débutant·e·s ont été très
 enrichissantes, notamment pour permettre d'améliorer les supports et
 tutoriaux.
 
-Nous ouvrirons dans quelques semaines l'appel à conférenciers et un
+Nous ouvrirons dans quelques semaines l'appel à conférenci·ères·ers et un
 recensement des sprints que vous souhaitez proposer.
 
 D'ici là nous comptons sur vous pour réfléchir sérieusement à ce que
 vous aimeriez présenter.
 
-Une équipe a été monté pour aider les personnes qui souhaiteraient de
+Une équipe a été montée pour aider les personnes qui souhaiteraient de
 l'aide pour préparer leur conférence ou pour répéter et recevoir des
 retours... alors vraiment n'hésitez pas.

--- a/content/pages/about.html
+++ b/content/pages/about.html
@@ -13,8 +13,9 @@
         Organisée chaque année depuis 10 ans
         par <a href="http://www.afpy.org/">l'AFPy</a>, cette conférence est
         gratuite, entièrement organisée par des bénévoles et regroupe
-        développeurs, chercheurs, étudiants et amateurs autour d'une même
-        passion pour le langage de programmation <a href="http://www.python.org/">Python.</a>
+        développeu·rs·ses, chercheu·rs·ses, étudiant·e·s et amat·eur·rice·s autour
+        d'une même passion pour le langage de programmation
+        <a href="http://www.python.org/">Python.</a>
       </p>
     </section>
 
@@ -53,9 +54,9 @@
       </p>
 
       <p>
-        Les développeurs de différents projets open-source se rejoignent pour
-        coder ensemble. Tout le monde est le bienvenu pour contribuer et les
-        nouveaux aussi.
+        Les développeu·rs·ses de différents projets open-source se rejoignent pour
+        coder ensemble. Chacun·e est l·e·a bienvenu·e pour contribuer, et les
+        nouve·aux·lles aussi.
       </p>
 
       <p>

--- a/content/pages/about.html
+++ b/content/pages/about.html
@@ -75,7 +75,7 @@
 
     <section>
       <h2>Appel à propositions</h2>
-      <p>Vous souhaitez proposer un sujet ? L'appel à orateurs est ouvert jusqu'au <strong id="cfp">dimanche 17 juillet</strong>.</p>
+      <p>Vous souhaitez proposer un sujet ? L'appel à orat·eurs·rices est ouvert jusqu'au <strong id="cfp">dimanche 17 juillet</strong>.</p>
       <p>
         <a href="https://www.fourmilieres.net/#/form/cae777e834c645b9">Proposez une conférence / un atelier</a>
       </p>

--- a/content/pages/programme.rst
+++ b/content/pages/programme.rst
@@ -17,7 +17,7 @@ ajouterons votre projet au programme des sprints.
 Conférences
 ===========
 
-L'appel à orateurs est ouvert jusqu'au dimanche 17 juillet.
+L'appel à orat·rices·eurs est ouvert jusqu'au dimanche 17 juillet.
 
 Vous pouvez proposer une conférence `sur le formulaire suivant`_.
 


### PR DESCRIPTION
Utilisation de langage non sexiste (cf https://fr.wikipedia.org/wiki/Langage_non_sexiste#Fran.C3.A7ais) pour l'ensemble du site.
