### PR TITLE
Revert "Changed talk propositions closing date to July the 31th"

### DIFF
--- a/content/2016.06.appel.a.conferenciers.rst
+++ b/content/2016.06.appel.a.conferenciers.rst
@@ -65,7 +65,7 @@ Nous acceptons des présentations longues (45mn) et courtes (25mn) et
 des ateliers (à vous de nous préciser leur durée en fonction du
 besoin).  Lien pour nous faire vos propositions : `fourmiliere.net`_.
 
-Attention, la date limite est fixée au **31 juillet** !
+Attention, la date limite est fixée au **17 juillet** !
 
 En espérant crouler sous les propositions,
 

--- a/content/pages/about.html
+++ b/content/pages/about.html
@@ -75,7 +75,7 @@
 
     <section>
       <h2>Appel à propositions</h2>
-      <p>Vous souhaitez proposer un sujet ? L'appel à orat·eurs·rices est ouvert jusqu'au <strong id="cfp">dimanche 31 juillet</strong>.</p>
+      <p>Vous souhaitez proposer un sujet ? L'appel à orat·eurs·rices est ouvert jusqu'au <strong id="cfp">dimanche 17 juillet</strong>.</p>
       <p>
         <a href="https://www.fourmilieres.net/#/form/cae778e834c645b9">Proposez une conférence / un atelier</a>
       </p>

--- a/content/pages/programme.rst
+++ b/content/pages/programme.rst
@@ -13,7 +13,7 @@ Conférences
 
 Les conférences auront lieu le samedi 15 et dimanche 16 Octobre.
 
-L'appel à orat·rices·eurs est ouvert jusqu'au **dimanche 31 juillet**.
+L'appel à orat·rices·eurs est ouvert jusqu'au **dimanche 17 juillet**.
 
 Vous souhaitez proposer une conférence ? Merci d'utiliser le `formulaire
 d'appel à propositions <https://www.fourmilieres.net/#/form/cae778e834c645b9>`_


### PR DESCRIPTION
This reverts commit 5ea5a1fae8789e5081cad195d90813522a7f4d4c.

See discussion in #17. Bottom line is that I think we shouldn't change the deadline now but after the first one is hit, in order to really have two deadlines (people start to freak out a few days before the first deadline is hit)
